### PR TITLE
init `record_llm_call`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,3 @@ jobs:
         run: |
           coverage run --branch -m pytest tests -vv
           coverage report
-
-      - name: Run mkdocs build
-        run: |
-          mkdocs build --verbose --clean

--- a/context/state_of_the_union.txt
+++ b/context/state_of_the_union.txt
@@ -1,0 +1,147 @@
+THE PRESIDENT:  Good afternoon.  Today, as we watch freedom and liberty under attack abroad, I’m here to fulfill my responsibilities under the Constitution to preserve freedom and liberty here in the United States of America. 
+ 
+And it’s my honor to introduce to the country a daughter of former public school teachers, a proven consensus builder, an accomplished lawyer, a distinguished jurist — one of the nation’s most — on one of the nation’s most prestigious courts.  My nominee for the United States Supreme Court is Judge Ketanji Jackson.
+ 
+You know, four weeks ago, when a member of the Court — a friend of mine; we used to work together in the Senate — Justice Stephen Breyer, announced his retirement, I said then choosing someone to serve on the United States Supreme Court is one of the most serious constitutional responsibilities a President has.  And I mean it. 
+ 
+I promised the process would be rigorous, that I would select a nominee worthy of Justice Breyer’s legacy of excellence and decency — someone extremely qualified, with a brilliant legal mind, with the utmost character and integrity, which are equally as important.
+ 
+And that I would bring this decision — to this decision my perspective as a lawyer; a former Constitutional law professor; chairman of the Judiciary Committee for many, many years; and — I’m almost reluctant to say it — someone who has presided over more Supreme Court nominations than almost anyone living today, which makes me 28 years old — (laughter) — I started doing it when I was 32 — and who has devoted much of my career to thinking about the Constitution and the role of the Supreme Court.
+ 
+With that perspective, I carefully studierd [sic] the re- — studied the records of candidates.  I’ve invited senators of both parties to offer their ideas and points of view, and I’ve met with a number of them. 
+ 
+As a result, because I truly respect not only the consent — I know they give consent, but it says — the Constitution says ”advice and consent,” and I sought the advice of Democrats and Republicans. 
+ 
+I’ve consulted with leading legal scholars and lawyers.
+ 
+And I’ve been fortunate to have the advice of the — Vice President Harris — and I mean this sincerely — an exceptional lawyer, a former Attorney General of California, and a former member of the Senate Judiciary Committee.
+ 
+And during this process, I looked for someone who, like Justice Breyer, has a pragmatic understanding that the law must work for the American people.  Someone who has the historical perspective to understand that the Constitution is a resilient charter of liberty.  Someone with the wisdom to appreciate that the Constitution protects certain inalienable rights — rights that fall within the most fundamental personal freedoms that our society recognizes.
+ 
+And then, someone with extraordinary character, who will bring to the Supreme Court an independent mind, uncompromising integrity, and with a strong moral compass and the courage to stand up for what she thinks is right.
+ 
+For too long, our government, our courts haven’t looked like America.  And I believe it’s time that we have a Court that reflects the full talents and greatness of our nation with a nominee of extraordinary qualifications and that we inspire all young people to believe that they can one day serve their country at the highest level.
+ 
+I’ve admired these traits of pragmatism, historical perspective, wisdom, character in the jurists nominated by Republican presidents as well as Democratic presidents. 
+ 
+And today, I’m pleased to introduce to the American people a candidate who continues in this great tradition.
+ 
+Judge Jackson grew up in Miami, Florida.  And by the way, the mayor of Miami — a Republican — endorsed you; I thought that was interesting.  Her parents grew up with segregation but never gave up hope that their children would enjoy the true promise of America.
+ 
+Her parents graduated from Historic Brac- — Black Colleges and become public school teachers — her mom, a principal; her Dad, a teacher, who later went back to school and became a lawyer representing that very school district — that school board.
+ 
+Judge Jackson describes finding her love for the law from an apartment complex at the University of Miami where her dad was attending law school.  She’d draw in her coloring book at the dining room table, next to her dad’s law books.
+ 
+She grew up to be a star student — elected mayor of her junior high school and president of her high school class, where she was a standout — she was a standout on the speech and debate team.
+ 
+And it was after a debate tournament that took place at Harvard when she was in high school that she believed she could one day be a student there.  There were those who told her she shouldn’t set her sights too high, but she refused to accept limits others set for her. 
+ 
+She did go on to Harvard undergraduate school, where she graduated magna cum laude.  She went into — to attend Harvard Law School, where she was a top student and editor of the prestigious Law Review.
+ 
+Then she applied for a highly competitive and coveted clerkship on the United States Supreme Court, and she was selected.
+ 
+The justice who thought that she was worthy of this high honor was a young lawyer.  It was none other than Justice Stephen Breyer, who’s seat I am nominating her to fill. 
+ 
+Not only did she learn about being a judge from Justice Breyer himself, she saw the great rigor through which Justice Breyer approached his work.  She learned from his willingness to work with colleagues with different viewpoints — critical qualities for — in my view, for any Supreme Court Justice.
+ 
+Now, years later, she steps up to fill Justice Breyer’s place on the Court with a uniquely accomplished and wide-ranging background.
+ 
+She has served both in public service as a federal public defender — a federal public defender and in private law practice as an accomplished lawyer in pr- — with a prestigious law firm.
+ 
+If confirmed, she will join Justice Sotomayor as the only other member of the United States Supreme Court who has experience as a trial court judge –- a critical qualification, in my view.
+ 
+And once again following in the footsteps of her mentor, Justice Breyer, she would become the only member of the Court who previously served as a member of the United States Sentencing Commission.
+ 
+And she brings an additional perspective to the Court as well.  She comes from a family of law enforcement, with her brother and uncles having served as police officers.
+ 
+That’s one reason, I expect, why the Fraternal Order of Police — the national organization — today said, and I quote, “There is little doubt [that] she has the temperament, the intellect, and the legal experience, and family background to have earned this appointment.”  And they went on to say they are confident she will, quote, “approach her future cases with an open mind and treat issues related to law enforcement fairly and justly.”
+ 
+Incredibly, Judge Jackson has already been confirmed by the United States Senate three times.
+ 
+First, to serve on the U.S. Sentencing Commission — a bipartisan, independent commission we help — I helped design to reduce the unwarranted disparities in sentencing and promote transparency and fairness in the criminal justice system. 
+ 
+On the commission, Judge Jackson was known for working with Democrats and Republicans to find common ground on critical issues.
+ 
+Second, she was concerned by — confirmed by the United States Senate with bipartisan support on the federal district court to administer justice with the special rigors and fairness that come with presiding over trials. 
+ 
+And third, she was confirmed with a bipartisan Senate vote to serve on U.S. Court of Appeals for the District of Columbia,  considered the second most powerful court behind the Supreme Court itself and the court she once argued cases before as a distinguished advocate. 
+ 
+And when Judge Jackson was nominated to this Circuit Court, one of its distinguished retired members, Judge Thomas Griffith, a former general counsel of Brigham Young University and a George Bush appointee to that court said he backed her “enthusiastically,” hailing her — hailing her “exemplary legal career in both public and private practice” and, he went on to say, her “careful approach” as a trial court judge.
+ 
+Judge Jackson’s service on the District Circuit Court of — for the D.C. Circuit Court of Appeals is another superb qualification for service on the Supreme Court.
+ 
+Three of her — of the current Supreme Court Justices also served with the D.C. Circuit judges where Judge Jackson now serves.
+ 
+Her opinions are always carefully reasoned, tethered to precedent, and demonstrate refrect — respect for how the law impacts everyday people.  It doesn’t mean she puts her thumb on the scale of justice one way or the other, but she understands the broader impact of her decisions.
+ 
+Whether it’s cases addressing the rights of workers or government service, she cares about making sure that our democracy works for the American people.
+ 
+She listens.  She looks people in the eye — lawyers, defendants, victims, and families. And she strives to ensure that everyone understands why she made a decision, what the law is, and what it means to them.  She strives to be fair, to get it right, to do justice. 
+ 
+That’s something all of us should remember, and it’s something I’ve thought about throughout this process.  And as a matter of fact, I thought about it walking over here with her.
+ 
+One floor below, we have several displays celebrating Black History Month.  One of them includes the judicial oath of office taken and signed by Justice Thurgood Marshall himself — an oath that will be once again administered to a distinguished American who will help write the next chapter in the history of the journey of America — a journey that Judge Jackson will take with her family. 
+ 
+I hope I don’t embarrass him, but her husband, Patrick — a surgeon — Dr. Patrick, stand up.  Let them see who you are.  There you go.  They met when they were undergraduate students at Harvard, and he’s a distinguished cancer surgeon at Georgetown. 
+ 
+And like so many women in this country, Judge Jackson is a working mom.  She had her eldest child, Talia, when she was a private lawyer in practice.  She had her second child, Leila, when she served as U- — on the U.S. Sentencing Commission.  Stand up, Leila.  I asked Leila, when I showed her through the office, whether she’d like to be president.  She looked, “No, I don’t know about that.”  (Laughter.)  There’s other things that — anyway, Leila, you’re welcome to be here.  Thank you so much. 
+ 
+And welcome your sister, who’s up in school in Rhode Island now. 
+ 
+I have children and grandchildren.  Let me tell you, Judge, you’re always a mom.  That’s not going to change no matter what you’re doing.  You’re on — whether you’re on the Supreme Court or not. 
+ 
+And I’ve always had a deep respect for the Supreme Court and judiciary as a coequal branch of the government, and I mean it.  The Court is equally as important as the presidency or the Congress.  It’s coequal. 
+ 
+So, today, I’m pleased to nominate Judge Jackson, who will bring extraordinary qualifications, deep experience and intellect, and a rigorous judicial record to the Court. 
+ 
+Judge Jackson deserves to be confirmed as the next justice of the Supreme Court.  I’ve met with the chairman and ranking members of the Senate Judiciary Committee, Senator Dick Durbin, Senator Chuck Grassley, and my hope is that they will move promptly, and I know they’ll move fairly. 
+ 
+Judge Jackson, congratulations.  And the podium is yours.  Let me pull this out for you.  How — where is — there you go.  (The President adjusts the podium.)  You got it?  The button — okay.  See?  Presidents can’t do much.  Thank you.
+ 
+JUDGE JACKSON:  Thank you, Mr. President.  Thank you.  (Applause.)
+ 
+Thank you very much, Mr. President.  I am truly humbled by the extraordinary honor of this nomination.  And I am especially grateful for the care that you have taken in discharging your constitutional duty in service of our democracy with all that is going on in the world today. 
+ 
+I also offer my sincerest thanks to you as well, Madam Vice President, for your invaluable role in this nomination process. 
+ 
+I must begin these very brief remarks by thanking God for delivering me to this point in my professional journey.  My life has been blessed beyond measure, and I do know that one can only come this far by faith.
+ 
+Among my many blessings — and indeed, the very first — is the fact that I was born in this great country.  The United States of America is the greatest beacon of hope and democracy the world has ever known. 
+ 
+I was also blessed from my early days to have had a supportive and loving family.  My mother and father, who have been married for 54 years, are at their home in Florida right now, and I know that they could not be more proud. 
+ 
+It was my father who started me on this path.  When I was a child, as the President mentioned, my father made the fateful decision to trans- — to transition from his job as a public high school history teacher and go to law school.  Some of my earliest memories are of him sitting at the kitchen table, reading his law books.  I watched him study and he became my first professional role model. 
+ 
+My mother, who was also a public high school teacher, provided invaluable support in those early days, working full-time to enable my father’s career transition while also guiding and inspiring four-year-old me.
+ 
+My only sibling — my brother, Ketajh — came along half a decade later, and I am so proud of all that he’s accomplished. After graduating from Howard University, he became a police officer and a detective on some of the toughest streets in the inner city of Baltimore.  After that, he enlisted in the Army, serving two tours of duty in the Middle East.  I believe that he was following the example set by my uncles who are in law enforcement. 
+ 
+You may have read that I have one uncle who got caught up in the drug trade and received a life sentence.  That is true, but law enforcement also runs in my family.  In addition to my brother, I had two uncles who served decades as police officers, one of whom became the police chief in my hometown of Miami, Florida. 
+ 
+I am standing here today by the grace of God as testament to the love and support that I’ve received from my family. 
+ 
+I have also been blessed with many dear friends, colleagues, mentors, law clerks.  I could not possibly name all of the people to whom I owe great thanks.  But I must mention specifically the three brilliant jurists for whom I had the privilege of serving as a law clerk at the outset of my legal career: U.S. District Judge Patti Saris in Massachusetts, U.S. Court of Appeals Bruce — Judge Bruce Selya in Rhode Island, and last but certainly not least, Associate Justice Stephen Breyer of the Supreme Court of the United States. 
+ 
+Justice Breyer, in particular, not only gave me the greatest job that any young lawyer could ever hope to have, but he also exemplified every day in every way that a Supreme Court Justice can perform at the highest level of skill and integrity while also being guided by civility, grace, pragmatism, and generosity of spirit. 
+ 
+Justice Breyer, the members of the Senate will decide if I fill your seat, but please know that I could never fill your shoes. 
+ 
+To my dear family, those who are here with me now and those who are watching from home, I am forever indebted to you for your love and support. 
+ 
+To my beloved husband, Patrick, thank you for being my rock today and every day for these past 26 years.  I love you.
+ 
+To my daughters, Talia and Leila, you are the light of my life.  Please know that whatever title I may hold or whatever job I might — may have, I will still be your mom.  That will never change. 
+ 
+There are so many other people I would love to be able to address and to thank, but time is short.  So, let me end by sharing an interesting coincidence that has actually meant a great deal to me over the years. 
+ 
+As it happens, I share a birthday with the first Black woman ever to be appointed as a federal judge: the Honorable Constance Baker Motley.  We were born exactly 49 years to the day apart. 
+ 
+Today, I proudly stand on Judge Motley’s shoulders, sharing not only her birthday but also her steadfast and courageous commitment to equal justice under law. 
+ 
+Judge Motley’s life and career has been a true inspiration to me as I have pursued this professional path.  And if I am fortunate enough to be confirmed as the next Associate Justice of the Supreme Court of the United States, I can only hope that my life and career, my love of this country and the Constitution, and my commitment to upholding the rule of law and the sacred principles upon which this great nation was founded will inspire future generations of Americans. 
+ 
+Thank you again, Mr. President, for this extraordinary honor.  (Applause.)
+ 
+THE PRESIDENT:  I forgot to introduce the First Lady, Dr. Jill Biden, and the Second Gentleman.  I — that seems strange to say that, but the Second — Doug is — Emhoff.  They’re both here as well.  So, thank you.  
+ 
+Thank you all.  (Applause.)

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,6 +1,0 @@
----
-description: 
-notes: This documentation page is generated from source file docstrings.
----
-
-::: prefect_langchain.flows

--- a/docs/gen_examples_catalog.py
+++ b/docs/gen_examples_catalog.py
@@ -72,7 +72,6 @@ def get_code_examples(obj: Union[ModuleType, Callable]) -> Set[str]:
 
 code_examples_grouping = defaultdict(set)
 for _, module_name, ispkg in iter_modules(prefect_langchain.__path__):
-
     module_nesting = f"{COLLECTION_SLUG}.{module_name}"
     module_obj = load_module(module_nesting)
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,4 +3,4 @@ description:
 notes: This documentation page is generated from source file docstrings.
 ---
 
-::: prefect_langchain.tasks
+::: prefect_langchain.plugins

--- a/prefect_langchain/__init__.py
+++ b/prefect_langchain/__init__.py
@@ -1,4 +1,3 @@
 from . import _version
-from .blocks import LangchainBlock  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_langchain/examples.py
+++ b/prefect_langchain/examples.py
@@ -9,12 +9,22 @@ from prefect_langchain.plugins import RecordLLMCalls
 
 def record_call_using_callable_llm():
     """Test LLM call wrapped when using a callable LLM."""
-    with RecordLLMCalls(tags={"testing"}):
+    with RecordLLMCalls():
         llm = OpenAI(temperature=0.9)
         text = (
             "What would be a good company name for a company that makes colorful socks?"
         )
         llm(text)
+
+
+async def record_call_using_callable_llm_async():
+    """Test LLM call wrapped when using a callable LLM."""
+    with RecordLLMCalls():
+        llm = OpenAI(temperature=0.9)
+        text = (
+            "What would be a good company name for a company that makes colorful socks?"
+        )
+        await llm.agenerate(text)
 
 
 def record_call_using_qa_with_sources_chain():
@@ -24,12 +34,14 @@ def record_call_using_qa_with_sources_chain():
     """
     loader = DirectoryLoader("context")
     index = VectorstoreIndexCreator().from_loaders([loader])
-    query = "What did the president say about Ketanji Brown Jackson"
+    query = "What did the president say about Ketanji Brown Jackson?"
 
-    with RecordLLMCalls():
+    with RecordLLMCalls(tags={index.vectorstore.__class__.__name__}):
         index.query_with_sources(query)
 
 
 if __name__ == "__main__":
+    # import asyncio
     record_call_using_callable_llm()
+    # asyncio.run(record_call_using_callable_llm_async())
     # record_call_using_qa_with_sources_chain()

--- a/prefect_langchain/examples.py
+++ b/prefect_langchain/examples.py
@@ -11,20 +11,20 @@ def record_call_using_callable_llm():
     """Test LLM call wrapped when using a callable LLM."""
     with RecordLLMCalls():
         llm = OpenAI(temperature=0.9)
-        text = (
-            "What would be a good company name for a company that makes colorful socks?"
-        )
-        llm(text)
+        llm("What would be a good name for a " "company that makes colorful socks?")
 
 
 async def record_call_using_callable_llm_async():
     """Test LLM call wrapped when using a callable LLM."""
     with RecordLLMCalls():
         llm = OpenAI(temperature=0.9)
-        text = (
-            "What would be a good company name for a company that makes colorful socks?"
+        await llm.agenerate(
+            [
+                "What would be a good name for a " "company that makes colorful socks?",
+                "What would be a good name for a "
+                "company that makes carbonated water?",
+            ]
         )
-        await llm.agenerate(text)
 
 
 def record_call_using_qa_with_sources_chain():
@@ -41,7 +41,9 @@ def record_call_using_qa_with_sources_chain():
 
 
 if __name__ == "__main__":
-    # import asyncio
+    import asyncio
+
+    asyncio.run(record_call_using_callable_llm_async())
+
     record_call_using_callable_llm()
-    # asyncio.run(record_call_using_callable_llm_async())
-    # record_call_using_qa_with_sources_chain()
+    record_call_using_qa_with_sources_chain()

--- a/prefect_langchain/examples.py
+++ b/prefect_langchain/examples.py
@@ -18,7 +18,6 @@ def test_record_call_using_callable_llm():
 def test_record_call_using_qa_with_sources_chain():
     """Test LLM call wrapped when using a QA with sources chain."""
     loader = DirectoryLoader("context")
-
     index = VectorstoreIndexCreator().from_loaders([loader])
     query = "What did the president say about Ketanji Brown Jackson"
     index.query_with_sources(query)
@@ -26,4 +25,4 @@ def test_record_call_using_qa_with_sources_chain():
 
 if __name__ == "__main__":
     test_record_call_using_callable_llm()
-    test_record_call_using_qa_with_sources_chain()
+    # test_record_call_using_qa_with_sources_chain()

--- a/prefect_langchain/examples.py
+++ b/prefect_langchain/examples.py
@@ -1,0 +1,29 @@
+"""Examples of how to use the prefect plugin for langchain."""
+
+from langchain.document_loaders.directory import DirectoryLoader
+from langchain.indexes import VectorstoreIndexCreator
+from langchain.llms import OpenAI
+
+from prefect_langchain.plugins import record_llm_call  # noqa
+
+
+def test_record_call_using_callable_llm():
+    """Test LLM call wrapped when using a callable LLM."""
+    llm = OpenAI(temperature=0.9)
+
+    text = "What would be a good company name for a company that makes colorful socks?"
+    llm(text)
+
+
+def test_record_call_using_qa_with_sources_chain():
+    """Test LLM call wrapped when using a QA with sources chain."""
+    loader = DirectoryLoader("context")
+
+    index = VectorstoreIndexCreator().from_loaders([loader])
+    query = "What did the president say about Ketanji Brown Jackson"
+    index.query_with_sources(query)
+
+
+if __name__ == "__main__":
+    test_record_call_using_callable_llm()
+    test_record_call_using_qa_with_sources_chain()

--- a/prefect_langchain/examples.py
+++ b/prefect_langchain/examples.py
@@ -4,25 +4,32 @@ from langchain.document_loaders.directory import DirectoryLoader
 from langchain.indexes import VectorstoreIndexCreator
 from langchain.llms import OpenAI
 
-from prefect_langchain.plugins import record_llm_call  # noqa
+from prefect_langchain.plugins import RecordLLMCalls
 
 
-def test_record_call_using_callable_llm():
+def record_call_using_callable_llm():
     """Test LLM call wrapped when using a callable LLM."""
-    llm = OpenAI(temperature=0.9)
+    with RecordLLMCalls(tags={"testing"}):
+        llm = OpenAI(temperature=0.9)
+        text = (
+            "What would be a good company name for a company that makes colorful socks?"
+        )
+        llm(text)
 
-    text = "What would be a good company name for a company that makes colorful socks?"
-    llm(text)
 
+def record_call_using_qa_with_sources_chain():
+    """Test LLM call wrapped when using a QA with sources chain.
 
-def test_record_call_using_qa_with_sources_chain():
-    """Test LLM call wrapped when using a QA with sources chain."""
+    Defaults to running local ChromaDB vectorstore for embeddings.
+    """
     loader = DirectoryLoader("context")
     index = VectorstoreIndexCreator().from_loaders([loader])
     query = "What did the president say about Ketanji Brown Jackson"
-    index.query_with_sources(query)
+
+    with RecordLLMCalls():
+        index.query_with_sources(query)
 
 
 if __name__ == "__main__":
-    test_record_call_using_callable_llm()
-    # test_record_call_using_qa_with_sources_chain()
+    record_call_using_callable_llm()
+    # record_call_using_qa_with_sources_chain()

--- a/prefect_langchain/plugins.py
+++ b/prefect_langchain/plugins.py
@@ -1,28 +1,46 @@
 """Module for defining Prefect plugins for langchain."""
 
 from functools import wraps
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from langchain.llms.base import BaseLLM
 from langchain.schema import LLMResult
 from prefect import flow
 from prefect.utilities.asyncutils import is_async_fn
 from prefect.utilities.collections import listrepr
+from pydantic import BaseModel
 
 
-def llm_invocation_summary(*args, **kwargs) -> Tuple[str, str]:
-    """Eventually an artifact."""
+class NotAnArtifact(BaseModel):
+    """Placeholder class for artifacts that are not yet implemented."""
+
+    name: str
+    description: str
+    content: Any
+
+
+def llm_invocation_summary(*args, **kwargs) -> NotAnArtifact:
+    """Will eventually return an artifact."""
     llm_endpoint = str(args[0].client)
     text_input = listrepr(args[-1])
 
-    return text_input, llm_endpoint
+    return NotAnArtifact(
+        name="LLM Invocation Summary",
+        description="Summary of the LLM invocation.",
+        content={"llm_endpoint": llm_endpoint, "text_input": text_input},
+    )
 
 
-def parse_llm_result(llm_result: LLMResult) -> Tuple[str, Dict[str, Any]]:
-    """Eventually an artifact."""
+def parse_llm_result(llm_result: LLMResult) -> NotAnArtifact:
+    """Will eventually return an artifact."""
     output = listrepr([g[0].text.strip("\n") for g in llm_result.generations])
     token_usage = llm_result.llm_output["token_usage"]
-    return output, token_usage
+
+    return NotAnArtifact(
+        name="LLM Result",
+        description="The result of the LLM invocation.",
+        content={"output": output, "token_usage": token_usage},
+    )
 
 
 def record_llm_call(func):
@@ -35,44 +53,50 @@ def record_llm_call(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             """async wrapper for LLM calls"""
-            text_input, llm_endpoint = llm_invocation_summary(*args, **kwargs)
+            invocation_artifact = llm_invocation_summary(*args, **kwargs)
+
+            llm_endpoint, text_input = invocation_artifact.content.values()
 
             @flow(**flow_kwargs)
             async def execute_llm_call(llm_endpoint: str, text_input: str):
                 """async flow for LLM calls"""
                 print(f"Sending {text_input} to {llm_endpoint}")
                 llm_result: LLMResult = await func(*args, **kwargs)
-                print(llm_result)
-                output = listrepr(
-                    [g[0].text.strip("\n") for g in llm_result.generations]
-                )
+
+                result_artifact = parse_llm_result(llm_result)
+
+                output, token_usage = result_artifact.content.values()
+
                 print(f"Received output from LLM: {output}")
-                print(f"Token Usage {llm_result.llm_output!r}")
+                print(f"Token Usage: {token_usage!r}")
                 return llm_result
 
-            return execute_llm_call(text_input, llm_endpoint)
+            return execute_llm_call(llm_endpoint, text_input)
 
     else:
 
         @wraps(func)
         def wrapper(*args, **kwargs):
             """sync wrapper for LLM calls"""
-            llm_endpoint, text_input = llm_invocation_summary(*args, **kwargs)
+            invocation_artifact = llm_invocation_summary(*args, **kwargs)
+
+            llm_endpoint, text_input = invocation_artifact.content.values()
 
             @flow(**flow_kwargs)
             def execute_llm_call(llm_endpoint: str, text_input: str):
                 """async flow for LLM calls"""
                 print(f"Sending {text_input} to {llm_endpoint}")
                 llm_result: LLMResult = func(*args, **kwargs)
-                print(llm_result)
-                output = listrepr(
-                    [g[0].text.strip("\n") for g in llm_result.generations]
-                )
+
+                result_artifact = parse_llm_result(llm_result)
+
+                output, token_usage = result_artifact.content.values()
+
                 print(f"Received output from LLM: {output}")
-                print(f"Token Usage: {llm_result.llm_output!r}")
+                print(f"Token Usage: {token_usage!r}")
                 return llm_result
 
-            return execute_llm_call(text_input, llm_endpoint)
+            return execute_llm_call(llm_endpoint, text_input)
 
     return wrapper
 

--- a/prefect_langchain/plugins.py
+++ b/prefect_langchain/plugins.py
@@ -1,1 +1,83 @@
 """Module for defining Prefect plugins for langchain."""
+
+from functools import wraps
+from typing import Any, Dict, Tuple
+
+from langchain.llms.base import BaseLLM
+from langchain.schema import LLMResult
+from prefect import flow
+from prefect.utilities.asyncutils import is_async_fn
+from prefect.utilities.collections import listrepr
+
+
+def llm_invocation_summary(*args, **kwargs) -> Tuple[str, str]:
+    """Eventually an artifact."""
+    llm_endpoint = str(args[0].client)
+    text_input = listrepr(args[-1])
+
+    return text_input, llm_endpoint
+
+
+def parse_llm_result(llm_result: LLMResult) -> Tuple[str, Dict[str, Any]]:
+    """Eventually an artifact."""
+    output = listrepr([g[0].text.strip("\n") for g in llm_result.generations])
+    token_usage = llm_result.llm_output["token_usage"]
+    return output, token_usage
+
+
+def record_llm_call(func):
+    """Decorator for warpping LLM calls made by langchain with a prefect flow."""
+
+    flow_kwargs = dict(name="Execute LLM Call", log_prints=True)
+
+    if is_async_fn(func):
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            """async wrapper for LLM calls"""
+            text_input, llm_endpoint = llm_invocation_summary(*args, **kwargs)
+
+            @flow(**flow_kwargs)
+            async def execute_llm_call(llm_endpoint: str, text_input: str):
+                """async flow for LLM calls"""
+                print(f"Sending {text_input} to {llm_endpoint}")
+                llm_result: LLMResult = await func(*args, **kwargs)
+                print(llm_result)
+                output = listrepr(
+                    [g[0].text.strip("\n") for g in llm_result.generations]
+                )
+                print(f"Received output from LLM: {output}")
+                print(f"Token Usage {llm_result.llm_output!r}")
+                return llm_result
+
+            return execute_llm_call(text_input, llm_endpoint)
+
+    else:
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            """sync wrapper for LLM calls"""
+            llm_endpoint, text_input = llm_invocation_summary(*args, **kwargs)
+
+            @flow(**flow_kwargs)
+            def execute_llm_call(llm_endpoint: str, text_input: str):
+                """async flow for LLM calls"""
+                print(f"Sending {text_input} to {llm_endpoint}")
+                llm_result: LLMResult = func(*args, **kwargs)
+                print(llm_result)
+                output = listrepr(
+                    [g[0].text.strip("\n") for g in llm_result.generations]
+                )
+                print(f"Received output from LLM: {output}")
+                print(f"Token Usage: {llm_result.llm_output!r}")
+                return llm_result
+
+            return execute_llm_call(text_input, llm_endpoint)
+
+    return wrapper
+
+
+for cls in BaseLLM.__subclasses__():
+    print(f"Wrapping {cls.__name__}")
+    cls.agenerate = record_llm_call(cls.agenerate)
+    cls.generate = record_llm_call(cls.generate)

--- a/prefect_langchain/utilities.py
+++ b/prefect_langchain/utilities.py
@@ -1,0 +1,8 @@
+"""Utilities for the prefect_langchain package."""
+
+import tiktoken
+
+
+def num_tokens(text: str) -> int:
+    """Return the number of tokens in the text."""
+    return len(tiktoken.encoding_for_model("text-davinci-003").encode(text))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ mkdocs-gen-files
 interrogate
 coverage
 pillow
+respx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.8.4
 langchain>=0.0.27
+tiktoken


### PR DESCRIPTION
PR introduces a `record_llm_call` that wraps the LLM API calls with a prefect flow

from what I can tell, all of langchain's LLM API calls go through `generate` / `agenerate` methods on subclasses of their `BaseLLM` class, so `record_llm_call` is just a decorator applied to all of those subclasses within a `RecordLLMCalls` context manager.

my retrieval of `content` from `NotAnArtifact` is gross and saddening but will make something cleaner when I can interact with real artifacts

## Example use
you just need a `OPENAI_API_KEY` in your env to run the examples, langchain finds it

```python
from langchain.llms import OpenAI
from prefect_langchain.plugins import RecordLLMCalls

with RecordLLMCalls():
    llm = OpenAI(temperature=0.9)
    text = (
        "What would be a good company name for a company that makes colorful socks?"
    )
    llm(text)
```
```console
❯ python prefect_langchain/examples.py
01:45:31.055 | INFO    | prefect.engine - Created flow run 'zippy-tapir' for flow 'Execute LLM Call'
01:45:31.784 | INFO    | Flow run 'Calling langchain.llms.openai at 2023-03-06 01:45:30' - Sending What would be a good company name for a company that makes colorful socks? to langchain.llms.openai
01:45:32.576 | INFO    | Flow run 'Calling langchain.llms.openai at 2023-03-06 01:45:30' - Recieved: name='LLM Result' description='The result of the LLM invocation.' content=LLMResult(generations=[[Generation(text='\n\nColorfulCozySocks', generation_info={'finish_reason': 'stop', 'logprobs': None})]], llm_output={'token_usage': {'prompt_tokens': 15, 'total_tokens': 23, 'completion_tokens': 8}})
01:45:32.699 | INFO    | Flow run 'zippy-tapir' - Finished in state Completed()
```


![image](https://user-images.githubusercontent.com/31014960/223048945-4d47f984-226b-4fd2-9973-b42381349627.png)